### PR TITLE
Add `pandoc-citeproc` and pkgdown action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -3,28 +3,33 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  release:
+    types: [published]
+  workflow_dispatch:
 
-name: R-CMD-check
+name: pkgdown
 
 jobs:
-  R-CMD-check:
+  pkgdown:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_KEEP_PKG_SOURCE: yes
     steps:
       - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: rcmdcheck
+          extra-packages: pkgdown
+          needs: website
 
-      - uses: r-lib/actions/check-r-package@v2
+      - name: Deploy package
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
Forgot to add the `pkgdown.yml` workflow.
In addition, the R CMD Check workflow requires `pandoc-citeproc` for the vignette.

The workflow now works as desired though R CMD check complains on quite a few things and fails therefore.